### PR TITLE
Query API

### DIFF
--- a/common/src/main/kotlin/com/github/clasicrando/common/AutoRelease.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/AutoRelease.kt
@@ -28,7 +28,7 @@ interface AutoRelease {
  * `finally` block. Errors thrown within the block or the [AutoRelease.release] method are
  * rethrown, suppressing the [AutoRelease.release] error if an error has already been thrown.
  */
-inline fun <A : AutoRelease, R> A.use(crossinline block: (A) -> R): R {
+inline fun <A : AutoRelease, R> A.use(block: (A) -> R): R {
     var cause: Throwable? = null
     return try {
         block(this)

--- a/common/src/main/kotlin/com/github/clasicrando/common/connection/Connection.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/connection/Connection.kt
@@ -1,6 +1,7 @@
 package com.github.clasicrando.common.connection
 
 import com.github.clasicrando.common.UniqueResourceId
+import com.github.clasicrando.common.query.Query
 import com.github.clasicrando.common.result.QueryResult
 import com.github.clasicrando.common.result.StatementResult
 

--- a/common/src/main/kotlin/com/github/clasicrando/common/connection/Connection.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/connection/Connection.kt
@@ -1,7 +1,9 @@
 package com.github.clasicrando.common.connection
 
 import com.github.clasicrando.common.UniqueResourceId
+import com.github.clasicrando.common.query.DefaultQueryBatch
 import com.github.clasicrando.common.query.Query
+import com.github.clasicrando.common.query.QueryBatch
 import com.github.clasicrando.common.result.QueryResult
 import com.github.clasicrando.common.result.StatementResult
 
@@ -78,6 +80,13 @@ interface Connection : UniqueResourceId {
      * Only call this method if you are sure you need it.
      */
     suspend fun releasePreparedStatement(query: String)
+
+    /** Create a new [Query] for this [Connection] with the specified [query] string */
+    fun createQuery(query: String): Query = Query(query, this)
+    /**
+     *
+     */
+    fun createQueryBatch(): QueryBatch = DefaultQueryBatch(this)
 }
 
 /**

--- a/common/src/main/kotlin/com/github/clasicrando/common/connection/Connection.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/connection/Connection.kt
@@ -83,9 +83,8 @@ interface Connection : UniqueResourceId {
 
     /** Create a new [Query] for this [Connection] with the specified [query] string */
     fun createQuery(query: String): Query = Query(query, this)
-    /**
-     *
-     */
+
+    /** Create a new [QueryBatch] for this [Connection] */
     fun createQueryBatch(): QueryBatch = DefaultQueryBatch(this)
 }
 

--- a/common/src/main/kotlin/com/github/clasicrando/common/exceptions/EmptyQueryResult.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/exceptions/EmptyQueryResult.kt
@@ -1,0 +1,8 @@
+package com.github.clasicrando.common.exceptions
+
+/**
+ * [KdbcException] thrown when a query result was expected to contain 1 or more rows, but zero were
+ * found
+ */
+class EmptyQueryResult(query: String)
+    : KdbcException("No results found in query result for:\n$query")

--- a/common/src/main/kotlin/com/github/clasicrando/common/exceptions/IncorrectScalarType.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/exceptions/IncorrectScalarType.kt
@@ -1,0 +1,10 @@
+package com.github.clasicrando.common.exceptions
+
+import kotlin.reflect.KClass
+
+/**
+ * [KdbcException] thrown when a scalar value is extracted but the expected type does not match the
+ * actual type
+ */
+class IncorrectScalarType(value: Any?, cls: KClass<*>)
+    : KdbcException("Could not convert $value into ${cls.simpleName}")

--- a/common/src/main/kotlin/com/github/clasicrando/common/exceptions/NoResultFound.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/exceptions/NoResultFound.kt
@@ -1,0 +1,5 @@
+package com.github.clasicrando.common.exceptions
+
+/** [KdbcException] thrown when a query is executed but no query result instances were collected */
+class NoResultFound(query: String)
+    : KdbcException("Could not find any results executing:\n$query")

--- a/common/src/main/kotlin/com/github/clasicrando/common/exceptions/RowParseError.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/exceptions/RowParseError.kt
@@ -1,0 +1,18 @@
+package com.github.clasicrando.common.exceptions
+
+import com.github.clasicrando.common.query.RowParser
+import com.github.clasicrando.common.result.DataRow
+
+/** [KdbcException] thrown when a [RowParser] fails to convert a [DataRow] into the required type */
+class RowParseError(
+    rowParser: RowParser<*>,
+    exception: Throwable? = null,
+    reason: String? = null,
+) : KdbcException(
+    "Failed to parse row into type using row parser ${rowParser::class.simpleName}"
+    + if (reason != null) ".$reason" else ""
+) {
+    init {
+        addSuppressed(exception)
+    }
+}

--- a/common/src/main/kotlin/com/github/clasicrando/common/exceptions/TooManyRows.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/exceptions/TooManyRows.kt
@@ -1,0 +1,8 @@
+package com.github.clasicrando.common.exceptions
+
+/**
+ * [KdbcException] thrown when a query result is expected to be exactly 1 row but multiple rows are
+ * found
+ */
+class TooManyRows(query: String)
+    : KdbcException("Query returns more than exactly 1 row. Query:\n$query")

--- a/common/src/main/kotlin/com/github/clasicrando/common/query/BlockingQuery.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/query/BlockingQuery.kt
@@ -1,0 +1,209 @@
+package com.github.clasicrando.common.query
+
+import com.github.clasicrando.common.AutoRelease
+import com.github.clasicrando.common.connection.BlockingConnection
+import com.github.clasicrando.common.connection.Connection
+import com.github.clasicrando.common.exceptions.EmptyQueryResult
+import com.github.clasicrando.common.exceptions.IncorrectScalarType
+import com.github.clasicrando.common.exceptions.NoResultFound
+import com.github.clasicrando.common.exceptions.RowParseError
+import com.github.clasicrando.common.exceptions.TooManyRows
+import com.github.clasicrando.common.result.QueryResult
+import com.github.clasicrando.common.result.StatementResult
+import com.github.clasicrando.common.use
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlin.reflect.KClass
+
+/**
+ * API to perform queries without interfacing with the more complex [BlockingConnection.sendQuery]
+ * and [BlockingConnection.sendPreparedStatement] methods. This allows the user to leverage a
+ * [BlockingConnection], optionally bind parameters to the [BlockingQuery] and then execute the
+ * query, fetching the results in common ways with helper methods. You can also reuse the query
+ * with new parameters by calling [clearParameters] between any of the `fetch` method calls to
+ * provide different parameters.
+ */
+open class BlockingQuery(
+    /** SQL Query to be executed against the database */
+    val query: String,
+    /** Reference to the [BlockingConnection] that backs this [BlockingQuery] */
+    @PublishedApi internal var connection: BlockingConnection?,
+) : AutoRelease {
+    /** Internal list of parameters that are bound to this [BlockingQuery] */
+    @PublishedApi
+    internal val parameters: MutableList<Any?> = mutableListOf()
+
+    /**
+     * Bind a next [parameter] to the [BlockingQuery]. This adds the parameter to the internal list of
+     * parameters in the order the parameter exists in the query regardless of the vendor specific
+     * method of linking parameter values to query parameters.
+     *
+     * Returns a reference to the [BlockingQuery] to allow for method chaining.
+     */
+    fun bind(parameter: Any?): BlockingQuery {
+        parameters += parameter
+        return this
+    }
+
+    /**
+     * Bind the [parameters] to the [BlockingQuery]. This adds each parameter to the internal list of
+     * parameters in the order the parameter exists in the query regardless of the vendor specific
+     * method of linking parameter values to query parameters.
+     *
+     * Returns a reference to the [BlockingQuery] to allow for method chaining.
+     */
+    fun bindMany(parameters: Collection<Any?>): BlockingQuery {
+        this.parameters.addAll(parameters)
+        return this
+    }
+
+    /**
+     * Bind the [parameters] to the [BlockingQuery]. This adds each parameter to the internal list of
+     * parameters in the order the parameter exists in the query regardless of the vendor specific
+     * method of linking parameter values to query parameters.
+     *
+     * Returns a reference to the [BlockingQuery] to allow for method chaining.
+     */
+    fun bindMany(vararg parameters: Any?): BlockingQuery {
+        this.parameters.addAll(parameters)
+        return this
+    }
+
+    /** Clears all parameters previously bound to this [BlockingQuery]  */
+    fun clearParameters() {
+        parameters.clear()
+    }
+
+    /**
+     * Simply execute the query and return the raw [StatementResult]. Use this if you have a
+     * non-SELECT DML statement to execute (e.g. an INSERT query where there is no result).
+     *
+     * @throws IllegalStateException if the query has already been closed
+     */
+    fun execute(): StatementResult {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters)
+    }
+
+    /**
+     * Execute the query and return the first row's first column as the type [T]. Returns null if
+     * the return value is null or the query result has no rows.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws IncorrectScalarType if the scalar value is not an instance of the type [T], this
+     * checked by [KClass.isInstance] on the first value
+     */
+    inline fun <reified T : Any> fetchScalar(): T? {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first()
+                .use { queryResult -> queryResult.extractScalar() }
+        }
+    }
+
+    /**
+     * Execute the query and return the first row parsed as the type [T] by the supplied
+     * [rowParser]. Returns null if the query results no rows.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     */
+    fun <T : Any, R : RowParser<T>> fetchFirst(rowParser: R): T? {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first()
+                .use { queryResult -> queryResult.extractFirst(rowParser) }
+        }
+    }
+
+    /**
+     * Execute the query and return the first row parsed as the type [T] by the supplied
+     * [rowParser].
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     * @throws EmptyQueryResult if the query returns no rows
+     * @throws TooManyRows if the [QueryResult.rowsAffected] value > 1
+     */
+    fun <T : Any, R : RowParser<T>> fetchSingle(rowParser: R): T {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first()
+                .use { queryResult ->
+                    if (queryResult.rowsAffected > 1) {
+                        throw TooManyRows(query)
+                    }
+                    queryResult.extractFirst(rowParser) ?: throw EmptyQueryResult(query)
+                }
+        }
+    }
+
+    /**
+     * Execute the query and return the all rows in a [List] where each row is parsed as the type
+     * [T] by the supplied [rowParser]. Returns an empty [List] when no rows are returned.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     */
+    fun <T : Any, R : RowParser<T>> fetchAll(rowParser: R): List<T> {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first()
+                .use { queryResult -> queryResult.extractAll(rowParser).toList() }
+        }
+    }
+
+    /**
+     * Execute the query and return the all rows as a [Flow] where each row is parsed as the type
+     * [T] by the supplied [rowParser]. Resulting [Flow] is cold so the connection is still in use
+     * until every row is collected or the [Flow] is canceled.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     */
+    fun <T : Any, R : RowParser<T>> fetch(rowParser: R): Sequence<T> = sequence {
+        checkNotNull(connection) { "Query already released its Connection" }
+        connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first()
+                .use { queryResult ->
+                for (row in queryResult.rows) {
+                    try {
+                        yield(rowParser.fromRow(row))
+                    } catch (ex: RowParseError) {
+                        throw ex
+                    } catch (ex: Throwable) {
+                        throw RowParseError(rowParser, ex)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun release() {
+        connection = null
+    }
+}

--- a/common/src/main/kotlin/com/github/clasicrando/common/query/BlockingQueryBatch.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/query/BlockingQueryBatch.kt
@@ -1,0 +1,54 @@
+package com.github.clasicrando.common.query
+
+import com.github.clasicrando.common.AutoRelease
+import com.github.clasicrando.common.connection.BlockingConnection
+import com.github.clasicrando.common.connection.Connection
+import com.github.clasicrando.common.result.QueryResult
+import com.github.clasicrando.common.result.StatementResult
+
+/**
+ * A batch of [BlockingQuery] instances can be executed and aggregated into a single
+ * [StatementResult] for convenience since the basic [BlockingQuery] API doesn't provide the
+ * ability to execute multiple queries at once or extract multiple result blocks from queries.
+ */
+abstract class BlockingQueryBatch(protected var connection: BlockingConnection?) : AutoRelease {
+    private val queries: MutableList<BlockingQuery> = mutableListOf()
+
+    /**
+     * Implementation specific method to execute and aggregate the results returned from the
+     * database server into a single [StatementResult].
+     */
+    protected abstract fun executeQueriesAggregating(
+        queries: List<Pair<String, List<Any?>>>
+    ): StatementResult
+
+    /**
+     * Execute all provided queries into a single [StatementResult] and allow for processing each
+     * [QueryResult] returned.
+     */
+    fun executeQueries(): StatementResult {
+        checkNotNull(connection) { "QueryBatch already released its Connection" }
+        if (queries.isEmpty()) {
+            return StatementResult(emptyList())
+        }
+        return executeQueriesAggregating(queries.map { it.query to it.parameters })
+    }
+
+    /**
+     * Create a new [BlockingQuery] using the provided [query] [String] and add it to the queries
+     * contained within this batch of queries. Returns the newly created [BlockingQuery] so
+     * parameters can be added if needed.
+     *
+     * @throws IllegalStateException if the batch has already been released
+     */
+    fun addQuery(query: String): BlockingQuery {
+        checkNotNull(connection) { "BlockingQuery already released its BlockingConnection" }
+        val result = connection!!.createQuery(query)
+        queries += result
+        return result
+    }
+
+    override fun release() {
+        connection = null
+    }
+}

--- a/common/src/main/kotlin/com/github/clasicrando/common/query/DefaultBlockingQueryBatch.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/query/DefaultBlockingQueryBatch.kt
@@ -1,0 +1,31 @@
+package com.github.clasicrando.common.query
+
+import com.github.clasicrando.common.connection.BlockingConnection
+import com.github.clasicrando.common.connection.Connection
+import com.github.clasicrando.common.result.StatementResult
+
+/**
+ * Default implementation of [BlockingQueryBatch] that naively executes each query sequentially and
+ * aggregates the results into a single [StatementResult]. This is only to be leveraged if the
+ * database does not provide a more efficient way to batch queries.
+ */
+class DefaultBlockingQueryBatch(connection: BlockingConnection) : BlockingQueryBatch(connection) {
+    override fun executeQueriesAggregating(
+        queries: List<Pair<String, List<Any?>>>,
+    ): StatementResult {
+        checkNotNull(connection) { "QueryBatch already released its Connection" }
+        val statementResultBuilder = StatementResult.Builder()
+        try {
+            for ((query, parameters) in queries) {
+                val statementResult = connection!!.sendPreparedStatement(query, parameters)
+                for (result in statementResult) {
+                    statementResultBuilder.addQueryResult(result)
+                }
+            }
+        } catch (ex: Throwable) {
+            statementResultBuilder.build().release()
+            throw ex
+        }
+        return statementResultBuilder.build()
+    }
+}

--- a/common/src/main/kotlin/com/github/clasicrando/common/query/DefaultQueryBatch.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/query/DefaultQueryBatch.kt
@@ -1,0 +1,30 @@
+package com.github.clasicrando.common.query
+
+import com.github.clasicrando.common.connection.Connection
+import com.github.clasicrando.common.result.StatementResult
+
+/**
+ * Default implementation of [QueryBatch] that naively executes each query sequentially and
+ * aggregates the results into a single [StatementResult]. This is only to be leveraged if the
+ * database does not provide a more efficient way to batch queries.
+ */
+class DefaultQueryBatch(connection: Connection) : QueryBatch(connection) {
+    override suspend fun executeQueriesAggregating(
+        queries: List<Pair<String, List<Any?>>>,
+    ): StatementResult {
+        checkNotNull(connection) { "QueryBatch already released its Connection" }
+        val statementResultBuilder = StatementResult.Builder()
+        try {
+            for ((query, parameters) in queries) {
+                val statementResult = connection!!.sendPreparedStatement(query, parameters)
+                for (result in statementResult) {
+                    statementResultBuilder.addQueryResult(result)
+                }
+            }
+        } catch (ex: Throwable) {
+            statementResultBuilder.build().release()
+            throw ex
+        }
+        return statementResultBuilder.build()
+    }
+}

--- a/common/src/main/kotlin/com/github/clasicrando/common/query/Query.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/query/Query.kt
@@ -1,0 +1,288 @@
+package com.github.clasicrando.common.query
+
+import com.github.clasicrando.common.AutoRelease
+import com.github.clasicrando.common.connection.Connection
+import com.github.clasicrando.common.datetime.DateTime
+import com.github.clasicrando.common.exceptions.EmptyQueryResult
+import com.github.clasicrando.common.exceptions.IncorrectScalarType
+import com.github.clasicrando.common.exceptions.NoResultFound
+import com.github.clasicrando.common.exceptions.RowParseError
+import com.github.clasicrando.common.exceptions.TooManyRows
+import com.github.clasicrando.common.result.QueryResult
+import com.github.clasicrando.common.result.StatementResult
+import com.github.clasicrando.common.use
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlin.reflect.KClass
+
+/**
+ * API to perform queries without interfacing with the more complex [Connection.sendQuery] and
+ * [Connection.sendPreparedStatement] methods. This allows the user to leverage a [Connection],
+ * optionally bind parameters to the [Query] and then execute the query, fetching the results in
+ * common ways with helper methods. You can also reuse the query with new parameters by calling
+ * [clearParameters] between any of the `fetch` method calls to provide different parameters.
+ */
+open class Query(
+    /** SQL Query to be executed against the database */
+    val query: String,
+    /** Reference to the [Connection] that backs this [Query] */
+    @PublishedApi internal var connection: Connection?,
+) : AutoRelease {
+    /** Internal list of parameters that are bound to this [Query] */
+    @PublishedApi
+    internal val parameters: MutableList<Any?> = mutableListOf()
+    /** Read-only [List] of the parameters currently bound to this [Query] */
+    val params: List<Any?> get() = parameters
+
+    /**
+     * Bind a next [parameter] to the [Query]. This adds the parameter to the internal list of
+     * parameters in the order the parameter exists in the query regardless of the vendor specific
+     * method of linking parameter values to query parameters.
+     *
+     * Returns a reference to the [Query] to allow for method chaining.
+     */
+    fun bind(parameter: Any?): Query {
+        parameters += parameter
+        return this
+    }
+
+    /**
+     * Bind the [parameters] to the [Query]. This adds each parameter to the internal list of
+     * parameters in the order the parameter exists in the query regardless of the vendor specific
+     * method of linking parameter values to query parameters.
+     *
+     * Returns a reference to the [Query] to allow for method chaining.
+     */
+    fun bindMany(parameters: Collection<Any?>): Query {
+        this.parameters.addAll(parameters)
+        return this
+    }
+
+    /**
+     * Bind the [parameters] to the [Query]. This adds each parameter to the internal list of
+     * parameters in the order the parameter exists in the query regardless of the vendor specific
+     * method of linking parameter values to query parameters.
+     *
+     * Returns a reference to the [Query] to allow for method chaining.
+     */
+    fun bindMany(vararg parameters: Any?): Query {
+        this.parameters.addAll(parameters)
+        return this
+    }
+
+    /** Clears all parameters previously bound to this [Query]  */
+    fun clearParameters() {
+        parameters.clear()
+    }
+
+    /**
+     * Simply execute the query and return the raw [StatementResult]. Use this if you have a
+     * non-SELECT DML statement to execute (e.g. an INSERT query where there is no result).
+     *
+     * @throws IllegalStateException if the query has already been closed
+     */
+    suspend fun execute(): StatementResult {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters)
+    }
+
+    /**
+     * Execute the query and return the first row's first column as the type [T]. Returns null if
+     * the return value is null or the query result has no rows.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws IncorrectScalarType if the scalar value is not an instance of the type [T], this
+     * checked by [KClass.isInstance] on the first value
+     */
+    suspend inline fun <reified T : Any> fetchScalar(): T? {
+        checkNotNull(connection) { "Query already released its Connection" }
+        val cls = T::class
+        return connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first().use { queryResult ->
+                queryResult.rows.firstOrNull()?.use { row ->
+                    val value = when (cls) {
+                        BOOLEAN_CLASS -> row.getBoolean(FIRST_INDEX)
+                        BYTE_CLASS -> row.getByte(FIRST_INDEX)
+                        SHORT_CLASS -> row.getShort(FIRST_INDEX)
+                        INT_CLASS -> row.getInt(FIRST_INDEX)
+                        LONG_CLASS -> row.getLong(FIRST_INDEX)
+                        FLOAT_CLASS -> row.getFloat(FIRST_INDEX)
+                        DOUBLE_CLASS -> row.getDouble(FIRST_INDEX)
+                        LOCAL_DATE_CLASS -> row.getLocalDate(FIRST_INDEX)
+                        LOCAL_TIME_CLASS -> row.getLocalTime(FIRST_INDEX)
+                        LOCAL_DATE_TIME_CLASS -> row.getLocalDateTime(FIRST_INDEX)
+                        DATETIME_CLASS -> row.getDateTime(FIRST_INDEX)
+                        STRING_CLASS -> row.getString(FIRST_INDEX)
+                        else -> row[FIRST_INDEX]
+                    }
+                    if (!cls.isInstance(value)) {
+                        throw IncorrectScalarType(value, cls)
+                    }
+                    value as T?
+                }
+            }
+        }
+    }
+
+    /**
+     * Execute the query and return the first row parsed as the type [T] by the supplied
+     * [rowParser]. Returns null if the query results no rows.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     */
+    suspend fun <T : Any, R : RowParser<T>> fetchFirst(rowParser: R): T? {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first().use { queryResult ->
+                queryResult.rows.firstOrNull()?.use { row ->
+                    try {
+                        rowParser.fromRow(row)
+                    } catch (ex: RowParseError) {
+                        throw ex
+                    } catch (ex: Throwable) {
+                        throw RowParseError(rowParser, ex)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Execute the query and return the first row parsed as the type [T] by the supplied
+     * [rowParser].
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     * @throws EmptyQueryResult if the query returns no rows
+     * @throws TooManyRows if the [QueryResult.rowsAffected] value > 1
+     */
+    suspend fun <T : Any, R : RowParser<T>> fetchSingle(rowParser: R): T {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first().use { queryResult ->
+                if (queryResult.rowsAffected > 1) {
+                    throw TooManyRows(query)
+                }
+                queryResult.rows.firstOrNull()?.use { row ->
+                    try {
+                        rowParser.fromRow(row)
+                    } catch (ex: RowParseError) {
+                        throw ex
+                    } catch (ex: Throwable) {
+                        throw RowParseError(rowParser, ex)
+                    }
+                } ?: throw EmptyQueryResult(query)
+            }
+        }
+    }
+
+    /**
+     * Execute the query and return the all rows in a [List] where each row is parsed as the type
+     * [T] by the supplied [rowParser]. Returns an empty [List] when no rows are returned.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     */
+    suspend fun <T : Any, R : RowParser<T>> fetchAll(rowParser: R): List<T> {
+        checkNotNull(connection) { "Query already released its Connection" }
+        return connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first().use { queryResult ->
+                queryResult.rows.map { row ->
+                    try {
+                        rowParser.fromRow(row)
+                    } catch (ex: RowParseError) {
+                        throw ex
+                    } catch (ex: Throwable) {
+                        throw RowParseError(rowParser, ex)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Execute the query and return the all rows as a [Flow] where each row is parsed as the type
+     * [T] by the supplied [rowParser]. Resulting [Flow] is cold so the connection is still in use
+     * until every row is collected or the [Flow] is canceled.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     */
+    suspend fun <T : Any, R : RowParser<T>> fetch(rowParser: R): Flow<T> = flow {
+        checkNotNull(connection) { "Query already released its Connection" }
+        connection!!.sendPreparedStatement(query, parameters).use { statementResult ->
+            if (statementResult.size == 0) {
+                throw NoResultFound(query)
+            }
+            statementResult.first().use { queryResult ->
+                for (row in queryResult.rows) {
+                    try {
+                        emit(rowParser.fromRow(row))
+                    } catch (ex: RowParseError) {
+                        throw ex
+                    } catch (ex: Throwable) {
+                        throw RowParseError(rowParser, ex)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun release() {
+        connection = null
+    }
+
+    companion object {
+        @PublishedApi
+        internal const val FIRST_INDEX = 0
+        @PublishedApi
+        internal val BOOLEAN_CLASS = Boolean::class
+        @PublishedApi
+        internal val BYTE_CLASS = Byte::class
+        @PublishedApi
+        internal val SHORT_CLASS = Short::class
+        @PublishedApi
+        internal val INT_CLASS = Int::class
+        @PublishedApi
+        internal val LONG_CLASS = Long::class
+        @PublishedApi
+        internal val FLOAT_CLASS = Float::class
+        @PublishedApi
+        internal val DOUBLE_CLASS = Double::class
+        @PublishedApi
+        internal val LOCAL_DATE_CLASS = LocalDate::class
+        @PublishedApi
+        internal val LOCAL_TIME_CLASS = LocalTime::class
+        @PublishedApi
+        internal val LOCAL_DATE_TIME_CLASS = LocalDateTime::class
+        @PublishedApi
+        internal val DATETIME_CLASS = DateTime::class
+        @PublishedApi
+        internal val STRING_CLASS = String::class
+    }
+}

--- a/common/src/main/kotlin/com/github/clasicrando/common/query/QueryBatch.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/query/QueryBatch.kt
@@ -1,0 +1,53 @@
+package com.github.clasicrando.common.query
+
+import com.github.clasicrando.common.AutoRelease
+import com.github.clasicrando.common.connection.Connection
+import com.github.clasicrando.common.result.QueryResult
+import com.github.clasicrando.common.result.StatementResult
+
+/**
+ * A batch of [Query] instances can be executed and aggregated into a single [StatementResult] for
+ * convenience since the basic [Query] API doesn't provide the ability to execute multiple queries
+ * at once or extract multiple result blocks from queries.
+ */
+abstract class QueryBatch(protected var connection: Connection?) : AutoRelease {
+    private val queries: MutableList<Query> = mutableListOf()
+
+    /**
+     * Implementation specific method to execute and aggregate the results returned from the
+     * database server into a single [StatementResult].
+     */
+    protected abstract suspend fun executeQueriesAggregating(
+        queries: List<Pair<String, List<Any?>>>
+    ): StatementResult
+
+    /**
+     * Execute all provided queries into a single [StatementResult] and allow for processing each
+     * [QueryResult] returned.
+     */
+    suspend fun executeQueries(): StatementResult {
+        checkNotNull(connection) { "QueryBatch already released its Connection" }
+        if (queries.isEmpty()) {
+            return StatementResult(emptyList())
+        }
+        return executeQueriesAggregating(queries.map { it.query to it.parameters })
+    }
+
+    /**
+     * Create a new [Query] using the provided [query] [String] and add it to the queries contained
+     * within this batch of queries. Returns the newly created [Query] so parameters can be added
+     * if needed.
+     *
+     * @throws IllegalStateException if the batch has already been released
+     */
+    fun addQuery(query: String): Query {
+        checkNotNull(connection) { "QueryBatch already released its Connection" }
+        val result = connection!!.createQuery(query)
+        queries += result
+        return result
+    }
+
+    override fun release() {
+        connection = null
+    }
+}

--- a/common/src/main/kotlin/com/github/clasicrando/common/query/RowParser.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/query/RowParser.kt
@@ -1,0 +1,298 @@
+package com.github.clasicrando.common.query
+
+import com.github.clasicrando.common.datetime.DateTime
+import com.github.clasicrando.common.exceptions.RowParseError
+import com.github.clasicrando.common.result.DataRow
+import com.github.clasicrando.common.result.getBoolean
+import com.github.clasicrando.common.result.getByte
+import com.github.clasicrando.common.result.getDateTime
+import com.github.clasicrando.common.result.getDouble
+import com.github.clasicrando.common.result.getFloat
+import com.github.clasicrando.common.result.getInt
+import com.github.clasicrando.common.result.getList
+import com.github.clasicrando.common.result.getLocalDate
+import com.github.clasicrando.common.result.getLocalDateTime
+import com.github.clasicrando.common.result.getLocalTime
+import com.github.clasicrando.common.result.getLong
+import com.github.clasicrando.common.result.getShort
+import com.github.clasicrando.common.result.getString
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.UtcOffset
+
+/** Implementors deserialize strategy for [DataRow] items into the required type [T] */
+interface RowParser<T : Any> {
+    /**
+     * Extract data from provided [row] to create a new instance of [T].
+     *
+     * @throws RowParseError if parser fails to convert the row into the desired type [T]
+     */
+    fun fromRow(row: DataRow): T
+}
+
+/**
+ * Extract the [dataRow] [Boolean] value at the specified [index], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getBoolean] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getBooleanOrThrow(dataRow: DataRow, index: Int): Boolean {
+    return dataRow.getBoolean(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Byte] value at the specified [index], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getByte] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getByteOrThrow(dataRow: DataRow, index: Int): Byte {
+    return dataRow.getByte(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Short] value at the specified [index], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getShort] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getShortOrThrow(dataRow: DataRow, index: Int): Short {
+    return dataRow.getShort(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Int] value at the specified [index], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getInt] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getIntOrThrow(dataRow: DataRow, index: Int): Int {
+    return dataRow.getInt(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Long] value at the specified [index], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getLong] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getLongOrThrow(dataRow: DataRow, index: Int): Long {
+    return dataRow.getLong(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Float] value at the specified [index], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getFloat] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getFloatOrThrow(dataRow: DataRow, index: Int): Float {
+    return dataRow.getFloat(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Double] value at the specified [index], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getDouble] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getDoubleOrThrow(dataRow: DataRow, index: Int): Double {
+    return dataRow.getDouble(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [LocalDate] value at the specified [index], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getLocalDate] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getLocalDateOrThrow(dataRow: DataRow, index: Int): LocalDate {
+    return dataRow.getLocalDate(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [LocalTime] value at the specified [index], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getLocalTime] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getLocalTimeOrThrow(dataRow: DataRow, index: Int): LocalTime {
+    return dataRow.getLocalTime(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [LocalDateTime] value at the specified [index], throwing a [RowParseError]
+ * if the value is null. Calls [DataRow.getLocalDateTime] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getLocalDateTimeOrThrow(dataRow: DataRow, index: Int): LocalDateTime {
+    return dataRow.getLocalDateTime(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [DateTime] value at the specified [index], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getDateTime] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getDateTimeOrThrow(dataRow: DataRow, index: Int): DateTime {
+    return dataRow.getDateTime(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [DateTime] value at the specified [index], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getDateTime] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getDateTimeOrThrow(
+    dataRow: DataRow,
+    index: Int,
+    offset: UtcOffset,
+): DateTime {
+    return dataRow.getDateTime(index, offset)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [String] value at the specified [index], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getString] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getStringOrThrow(dataRow: DataRow, index: Int): String {
+    return dataRow.getString(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [List] value at the specified [index], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getList] to extract the nullable value.
+ */
+fun <T : Any, E : Any> RowParser<T>.getList(dataRow: DataRow, index: Int): List<E?> {
+    return dataRow.getList(index)
+        ?: throw RowParseError(this, reason = "Column index $index must be non-null")
+}
+
+
+
+
+
+
+
+/**
+ * Extract the [dataRow] [Boolean] value at the specified [name], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getBoolean] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getBooleanOrThrow(dataRow: DataRow, name: String): Boolean {
+    return dataRow.getBoolean(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Byte] value at the specified [name], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getByte] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getByteOrThrow(dataRow: DataRow, name: String): Byte {
+    return dataRow.getByte(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Short] value at the specified [name], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getShort] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getShortOrThrow(dataRow: DataRow, name: String): Short {
+    return dataRow.getShort(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Int] value at the specified [name], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getInt] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getIntOrThrow(dataRow: DataRow, name: String): Int {
+    return dataRow.getInt(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Long] value at the specified [name], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getLong] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getLongOrThrow(dataRow: DataRow, name: String): Long {
+    return dataRow.getLong(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Float] value at the specified [name], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getFloat] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getFloatOrThrow(dataRow: DataRow, name: String): Float {
+    return dataRow.getFloat(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [Double] value at the specified [name], throwing a [RowParseError] if the
+ * value is null. Calls [DataRow.getDouble] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getDoubleOrThrow(dataRow: DataRow, name: String): Double {
+    return dataRow.getDouble(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [LocalDate] value at the specified [name], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getLocalDate] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getLocalDateOrThrow(dataRow: DataRow, name: String): LocalDate {
+    return dataRow.getLocalDate(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [LocalTime] value at the specified [name], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getLocalTime] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getLocalTimeOrThrow(dataRow: DataRow, name: String): LocalTime {
+    return dataRow.getLocalTime(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [LocalDateTime] value at the specified [name], throwing a [RowParseError]
+ * if the value is null. Calls [DataRow.getLocalDateTime] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getLocalDateTimeOrThrow(dataRow: DataRow, name: String): LocalDateTime {
+    return dataRow.getLocalDateTime(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [DateTime] value at the specified [name], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getDateTime] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getDateTimeOrThrow(dataRow: DataRow, name: String): DateTime {
+    return dataRow.getDateTime(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [DateTime] value at the specified [name], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getDateTime] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getDateTimeOrThrow(
+    dataRow: DataRow,
+    name: String,
+    offset: UtcOffset,
+): DateTime {
+    return dataRow.getDateTime(name, offset)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [String] value at the specified [name], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getString] to extract the nullable value.
+ */
+fun <T : Any> RowParser<T>.getStringOrThrow(dataRow: DataRow, name: String): String {
+    return dataRow.getString(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}
+
+/**
+ * Extract the [dataRow] [List] value at the specified [name], throwing a [RowParseError] if
+ * the value is null. Calls [DataRow.getList] to extract the nullable value.
+ */
+fun <T : Any, E : Any> RowParser<T>.getList(dataRow: DataRow, name: String): List<E?> {
+    return dataRow.getList(name)
+        ?: throw RowParseError(this, reason = "Column name '$name' must be non-null")
+}

--- a/common/src/main/kotlin/com/github/clasicrando/common/result/QueryResult.kt
+++ b/common/src/main/kotlin/com/github/clasicrando/common/result/QueryResult.kt
@@ -1,6 +1,16 @@
 package com.github.clasicrando.common.result
 
 import com.github.clasicrando.common.AutoRelease
+import com.github.clasicrando.common.datetime.DateTime
+import com.github.clasicrando.common.exceptions.IncorrectScalarType
+import com.github.clasicrando.common.exceptions.NoResultFound
+import com.github.clasicrando.common.exceptions.RowParseError
+import com.github.clasicrando.common.query.RowParser
+import com.github.clasicrando.common.use
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlin.reflect.KClass
 
 /**
  * Container class for the data returned upon completion of a query. Every query must have the
@@ -22,5 +32,110 @@ open class QueryResult(
     /** Releases all [rows] found within this result */
     override fun release() {
         rows.release()
+    }
+
+    /**
+     * Execute the query and return the first row's first column as the type [T]. Returns null if
+     * the return value is null or the query result has no rows.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws IncorrectScalarType if the scalar value is not an instance of the type [T], this
+     * checked by [KClass.isInstance] on the first value
+     */
+    inline fun <reified T : Any> extractScalar(): T? {
+        val cls = T::class
+        return rows.firstOrNull()?.use { row ->
+            val value = when (cls) {
+                BOOLEAN_CLASS -> row.getBoolean(FIRST_INDEX)
+                BYTE_CLASS -> row.getByte(FIRST_INDEX)
+                SHORT_CLASS -> row.getShort(FIRST_INDEX)
+                INT_CLASS -> row.getInt(FIRST_INDEX)
+                LONG_CLASS -> row.getLong(FIRST_INDEX)
+                FLOAT_CLASS -> row.getFloat(FIRST_INDEX)
+                DOUBLE_CLASS -> row.getDouble(FIRST_INDEX)
+                LOCAL_DATE_CLASS -> row.getLocalDate(FIRST_INDEX)
+                LOCAL_TIME_CLASS -> row.getLocalTime(FIRST_INDEX)
+                LOCAL_DATE_TIME_CLASS -> row.getLocalDateTime(FIRST_INDEX)
+                DATETIME_CLASS -> row.getDateTime(FIRST_INDEX)
+                STRING_CLASS -> row.getString(FIRST_INDEX)
+                else -> row[FIRST_INDEX]
+            }
+            if (!cls.isInstance(value)) {
+                throw IncorrectScalarType(value, cls)
+            }
+            value as T?
+        }
+    }
+
+    /**
+     * Return the first row parsed as the type [T] by the supplied [rowParser]. Returns null if the
+     * query results no rows.
+     *
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     */
+    fun <T : Any, R : RowParser<T>> extractFirst(rowParser: R): T? {
+        return rows.firstOrNull()
+            ?.use { row ->
+                try {
+                    rowParser.fromRow(row)
+                } catch (ex: RowParseError) {
+                    throw ex
+                } catch (ex: Throwable) {
+                    throw RowParseError(rowParser, ex)
+                }
+            }
+    }
+
+    /**
+     * Return the all rows as a [Sequence] where each row is parsed as the type [T] by the supplied
+     * [rowParser]. Returns an empty [Sequence] when no rows are returned.
+     *
+     * @throws IllegalStateException if the query has already been closed
+     * @throws NoResultFound if the execution result yields no [QueryResult]
+     * @throws RowParseError if the [rowParser] throws any [Throwable], thrown errors other than
+     * [RowParseError] are wrapped into a [RowParseError]
+     */
+    fun <T : Any, R : RowParser<T>> extractAll(rowParser: R): Sequence<T> {
+        return rows.asSequence()
+            .map { row ->
+                try {
+                    rowParser.fromRow(row)
+                } catch (ex: RowParseError) {
+                    throw ex
+                } catch (ex: Throwable) {
+                    throw RowParseError(rowParser, ex)
+                }
+            }
+    }
+
+    companion object {
+        @PublishedApi
+        internal const val FIRST_INDEX = 0
+        @PublishedApi
+        internal val BOOLEAN_CLASS = Boolean::class
+        @PublishedApi
+        internal val BYTE_CLASS = Byte::class
+        @PublishedApi
+        internal val SHORT_CLASS = Short::class
+        @PublishedApi
+        internal val INT_CLASS = Int::class
+        @PublishedApi
+        internal val LONG_CLASS = Long::class
+        @PublishedApi
+        internal val FLOAT_CLASS = Float::class
+        @PublishedApi
+        internal val DOUBLE_CLASS = Double::class
+        @PublishedApi
+        internal val LOCAL_DATE_CLASS = LocalDate::class
+        @PublishedApi
+        internal val LOCAL_TIME_CLASS = LocalTime::class
+        @PublishedApi
+        internal val LOCAL_DATE_TIME_CLASS = LocalDateTime::class
+        @PublishedApi
+        internal val DATETIME_CLASS = DateTime::class
+        @PublishedApi
+        internal val STRING_CLASS = String::class
     }
 }

--- a/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/column/Array.kt
+++ b/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/column/Array.kt
@@ -191,6 +191,9 @@ internal fun <T : Any, D : PgTypeDecoder<T>> arrayTypeDecoder(
             List(length) {
                 // Read length value but don't use it since a ReadBufferSlice cannot be constructed
                 val elementLength = value.bytes.readInt()
+                if (elementLength == -1) {
+                    return@List null
+                }
                 val slice = value.bytes.slice(elementLength)
                 value.bytes.skip(elementLength)
                 decoder.decode(PgValue.Binary(slice, fieldDescription))

--- a/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/column/Composite.kt
+++ b/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/column/Composite.kt
@@ -189,6 +189,9 @@ internal class PgCompositeTypeDecoder<T : Any>(
             val typeOid = PgType.fromOid(value.bytes.readInt())
             val fieldDescription = dummyTypedFieldDescription(typeOid.oid)
             val attributeLength = value.bytes.readInt()
+            if (attributeLength == -1) {
+                return@Array null
+            }
             val slice = value.bytes.slice(attributeLength)
             value.bytes.skip(attributeLength)
             val innerValue = PgValue.Binary(slice, fieldDescription)

--- a/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/connection/PgBlockingConnection.kt
+++ b/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/connection/PgBlockingConnection.kt
@@ -5,6 +5,7 @@ import com.github.clasicrando.common.Loop
 import com.github.clasicrando.common.connection.BlockingConnection
 import com.github.clasicrando.common.exceptions.UnexpectedTransactionState
 import com.github.clasicrando.common.pool.BlockingConnectionPool
+import com.github.clasicrando.common.query.BlockingQueryBatch
 import com.github.clasicrando.common.quoteIdentifier
 import com.github.clasicrando.common.reduceToSingleOrNull
 import com.github.clasicrando.common.resourceLogger
@@ -25,6 +26,7 @@ import com.github.clasicrando.postgresql.message.TransactionStatus
 import com.github.clasicrando.postgresql.notification.PgNotification
 import com.github.clasicrando.postgresql.pool.PgBlockingConnectionPool
 import com.github.clasicrando.postgresql.pool.PgBlockingPoolManager
+import com.github.clasicrando.postgresql.query.PgBlockingQueryBatch
 import com.github.clasicrando.postgresql.result.PgResultSet
 import com.github.clasicrando.postgresql.statement.PgArguments
 import com.github.clasicrando.postgresql.statement.PgPreparedStatement
@@ -836,6 +838,8 @@ class PgBlockingConnection internal constructor(
             arrayType = typeOf<List<T?>>(),
         )
     }
+
+    override fun createQueryBatch(): BlockingQueryBatch = PgBlockingQueryBatch(this)
 
     companion object {
         private const val STATEMENT_TEMPLATE = "Sending {query}"

--- a/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/connection/PgConnection.kt
+++ b/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/connection/PgConnection.kt
@@ -465,11 +465,9 @@ class PgConnection internal constructor(
 
         require(statement.paramCount == parameters.size) {
             """
-            Query does not have the correct number of parameters.
+            Query does not have the correct number of parameters. Expected ${statement.paramCount}, got ${parameters.size}
             
-            ${query.replaceIndent("            ")}
-            
-            Expected ${statement.paramCount}, got ${parameters.size}
+            ${query.trim().replaceIndent("            ")}
             """.trimIndent()
         }
 

--- a/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/connection/PgConnection.kt
+++ b/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/connection/PgConnection.kt
@@ -5,6 +5,7 @@ import com.github.clasicrando.common.Loop
 import com.github.clasicrando.common.connection.Connection
 import com.github.clasicrando.common.exceptions.UnexpectedTransactionState
 import com.github.clasicrando.common.pool.ConnectionPool
+import com.github.clasicrando.common.query.QueryBatch
 import com.github.clasicrando.common.quoteIdentifier
 import com.github.clasicrando.common.reduceToSingleOrNull
 import com.github.clasicrando.common.resourceLogger
@@ -25,6 +26,7 @@ import com.github.clasicrando.postgresql.message.TransactionStatus
 import com.github.clasicrando.postgresql.notification.PgNotification
 import com.github.clasicrando.postgresql.pool.PgConnectionPool
 import com.github.clasicrando.postgresql.pool.PgPoolManager
+import com.github.clasicrando.postgresql.query.PgQueryBatch
 import com.github.clasicrando.postgresql.result.PgResultSet
 import com.github.clasicrando.postgresql.statement.PgArguments
 import com.github.clasicrando.postgresql.statement.PgPreparedStatement
@@ -896,6 +898,8 @@ class PgConnection internal constructor(
             arrayType = typeOf<List<T?>>(),
         )
     }
+
+    override fun createQueryBatch(): QueryBatch = PgQueryBatch(this)
 
     companion object {
         private const val STATEMENT_TEMPLATE = "Sending {query}"

--- a/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/query/PgBlockingQueryBatch.kt
+++ b/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/query/PgBlockingQueryBatch.kt
@@ -1,0 +1,38 @@
+package com.github.clasicrando.postgresql.query
+
+import com.github.clasicrando.common.query.BlockingQueryBatch
+import com.github.clasicrando.common.result.StatementResult
+import com.github.clasicrando.postgresql.connection.PgBlockingConnection
+
+/**
+ * Postgresql implementation of a [BlockingQueryBatch]. Uses query pipelining to execute all
+ * prepared statements as a pipeline to optimize round trips to the server.
+ *
+ * @see PgBlockingConnection.pipelineQueries
+ */
+class PgBlockingQueryBatch(connection: PgBlockingConnection) : BlockingQueryBatch(connection) {
+    /** Sync all parameter provided to the [PgBlockingConnection.pipelineQueries] method */
+    var syncAll: Boolean = true
+
+    override fun executeQueriesAggregating(
+        queries: List<Pair<String, List<Any?>>>,
+    ): StatementResult {
+        checkNotNull(connection) { "QueryBatch already released its Connection" }
+        check(connection is PgBlockingConnection) {
+            "PgQueryBatch's connection is not PgConnection. This should never happen"
+        }
+        val statementResultBuilder = StatementResult.Builder()
+        try {
+            val pipelineQueries = Array(queries.size) { queries[it] }
+            val queryResults = (connection as PgBlockingConnection)
+                .pipelineQueries(syncAll = syncAll, queries = pipelineQueries)
+            for (queryResult in queryResults) {
+                statementResultBuilder.addQueryResult(queryResult)
+            }
+        } catch (ex: Throwable) {
+            statementResultBuilder.build().release()
+            throw ex
+        }
+        return statementResultBuilder.build()
+    }
+}

--- a/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/query/PgQueryBatch.kt
+++ b/postgresql/src/main/kotlin/com/github/clasicrando/postgresql/query/PgQueryBatch.kt
@@ -1,0 +1,38 @@
+package com.github.clasicrando.postgresql.query
+
+import com.github.clasicrando.common.query.QueryBatch
+import com.github.clasicrando.common.result.StatementResult
+import com.github.clasicrando.postgresql.connection.PgConnection
+
+/**
+ * Postgresql implementation of a [QueryBatch]. Uses query pipelining to execute all prepared
+ * statements as a pipeline to optimize round trips to the server.
+ *
+ * @see PgConnection.pipelineQueries
+ */
+class PgQueryBatch(connection: PgConnection) : QueryBatch(connection) {
+    /** Sync all parameter provided to the [PgConnection.pipelineQueries] method */
+    var syncAll: Boolean = true
+
+    override suspend fun executeQueriesAggregating(
+        queries: List<Pair<String, List<Any?>>>,
+    ): StatementResult {
+        checkNotNull(connection) { "QueryBatch already released its Connection" }
+        check(connection is PgConnection) {
+            "PgQueryBatch's connection is not PgConnection. This should never happen"
+        }
+        val statementResultBuilder = StatementResult.Builder()
+        try {
+            val pipelineQueries = Array(queries.size) { queries[it] }
+            (connection as PgConnection)
+                .pipelineQueries(syncAll = syncAll, queries = pipelineQueries)
+                .collect {
+                    statementResultBuilder.addQueryResult(it)
+                }
+        } catch (ex: Throwable) {
+            statementResultBuilder.build().release()
+            throw ex
+        }
+        return statementResultBuilder.build()
+    }
+}

--- a/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/PgConnectionHelper.kt
+++ b/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/PgConnectionHelper.kt
@@ -33,4 +33,8 @@ object PgConnectionHelper {
     fun defaultBlockingConnection(): PgBlockingConnection {
         return PgBlockingConnection.connect(connectOptions = defaultConnectOptions)
     }
+
+    fun defaultBlockingConnectionWithForcedSimple(): PgBlockingConnection {
+        return PgBlockingConnection.connect(connectOptions = defaultConnectOptionsWithForcedSimple)
+    }
 }

--- a/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/column/TestCompositeType.kt
+++ b/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/column/TestCompositeType.kt
@@ -17,6 +17,51 @@ class TestCompositeType {
     data class CompositeType(val id: Int, val text: String, val timestamp: DateTime)
 
     @Test
+    fun `encode should accept CompositeTest when querying blocking postgresql`() {
+        val query = "SELECT $1 composite_col;"
+
+        PgConnectionHelper.defaultBlockingConnection().use { conn ->
+            conn.registerCompositeType<CompositeType>("composite_type")
+            conn.sendPreparedStatement(query, listOf(type)).use { results ->
+                assertEquals(1, results.size)
+                assertEquals(1, results[0].rowsAffected)
+                val rows = results[0].rows.toList()
+                assertEquals(1, rows.size)
+                assertEquals(type, rows.map { it.getAs<CompositeType>("composite_col") }.first())
+            }
+        }
+    }
+
+    private fun decodeBlockingTest(isPrepared: Boolean) {
+        val query = "SELECT row(1,'Composite Type','2024-02-25T05:25:51Z')::composite_type;"
+
+        PgConnectionHelper.defaultBlockingConnectionWithForcedSimple().use { conn ->
+            conn.registerCompositeType<CompositeType>("composite_type")
+            if (isPrepared) {
+                conn.sendPreparedStatement(query, emptyList())
+            } else {
+                conn.sendQuery(query)
+            }.use { results ->
+                assertEquals(1, results.size)
+                assertEquals(1, results[0].rowsAffected)
+                val rows = results[0].rows.toList()
+                assertEquals(1, rows.size)
+                assertEquals(type, rows.map { it.getAs<CompositeType>(0)!! }.first())
+            }
+        }
+    }
+
+    @Test
+    fun `decode should return CompositeType when simple querying blocking postgresql composite`() {
+        decodeBlockingTest(isPrepared = false)
+    }
+
+    @Test
+    fun `decode should return CompositeType when extended querying blocking postgresql composite`() {
+        decodeBlockingTest(isPrepared = true)
+    }
+
+    @Test
     fun `encode should accept CompositeTest when querying postgresql`() = runBlocking {
         val query = "SELECT $1 composite_col;"
 

--- a/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/column/TestEnumType.kt
+++ b/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/column/TestEnumType.kt
@@ -19,6 +19,54 @@ class TestEnumType {
 
     @ParameterizedTest
     @EnumSource(value = EnumType::class)
+    fun `encode should accept EnumType when querying blocking postgresql`(value: EnumType) {
+        val query = "SELECT $1 enum_col;"
+
+        PgConnectionHelper.defaultBlockingConnection().use { conn ->
+            conn.registerEnumType<EnumType>("enum_type")
+            conn.sendPreparedStatement(query, listOf(value)).use { results ->
+                assertEquals(1, results.size)
+                assertEquals(1, results[0].rowsAffected)
+                val rows = results[0].rows.toList()
+                assertEquals(1, rows.size)
+                assertEquals(value, rows.map { it.getAs<EnumType>("enum_col") }.first())
+            }
+        }
+    }
+
+    private fun decodeBlockingTest(value: EnumType, isPrepared: Boolean) {
+        val query = "SELECT '$value'::enum_type;"
+
+        PgConnectionHelper.defaultBlockingConnectionWithForcedSimple().use { conn ->
+            conn.registerEnumType<EnumType>("enum_type")
+            if (isPrepared) {
+                conn.sendPreparedStatement(query, emptyList())
+            } else {
+                conn.sendQuery(query)
+            }.use { results ->
+                assertEquals(1, results.size)
+                assertEquals(1, results[0].rowsAffected)
+                val rows = results[0].rows.toList()
+                assertEquals(1, rows.size)
+                assertEquals(value, rows.map { it.getAs<EnumType>(0)!! }.first())
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EnumType::class)
+    fun `decode should return EnumType when simple querying blocking postgresql custom enum`(value: EnumType) {
+        decodeBlockingTest(value = value, isPrepared = false)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EnumType::class)
+    fun `decode should return EnumType when extended querying blocking postgresql custom enum`(value: EnumType) {
+        decodeBlockingTest(value = value, isPrepared = true)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EnumType::class)
     fun `encode should accept EnumType when querying postgresql`(value: EnumType) = runBlocking {
         val query = "SELECT $1 enum_col;"
 

--- a/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/query/TestPgBlockingQuery.kt
+++ b/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/query/TestPgBlockingQuery.kt
@@ -1,0 +1,235 @@
+package com.github.clasicrando.postgresql.query
+
+import com.github.clasicrando.common.connection.use
+import com.github.clasicrando.common.exceptions.EmptyQueryResult
+import com.github.clasicrando.common.exceptions.IncorrectScalarType
+import com.github.clasicrando.common.exceptions.RowParseError
+import com.github.clasicrando.common.exceptions.TooManyRows
+import com.github.clasicrando.common.query.RowParser
+import com.github.clasicrando.common.query.getIntOrThrow
+import com.github.clasicrando.common.query.getStringOrThrow
+import com.github.clasicrando.common.result.DataRow
+import com.github.clasicrando.common.result.getInt
+import com.github.clasicrando.common.use
+import com.github.clasicrando.postgresql.PgConnectionHelper
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class TestPgBlockingQuery {
+    data class Row(val intValue: Int, val stringValue: String)
+
+    object GoodRowParserTest : RowParser<Row> {
+        override fun fromRow(row: DataRow): Row {
+            return Row(
+                intValue = getIntOrThrow(row, "int_value"),
+                stringValue = getStringOrThrow(row, "string_value"),
+            )
+        }
+    }
+
+    object BadRowParserTest : RowParser<Row> {
+        override fun fromRow(row: DataRow): Row {
+            return Row(
+                intValue = row.getInt(3)!!,
+                stringValue = getStringOrThrow(row, "string_value"),
+            )
+        }
+    }
+
+    object BadRowParserTest2 : RowParser<Row> {
+        override fun fromRow(row: DataRow): Row {
+            return Row(
+                intValue = row.getInt("int_value")!!,
+                stringValue = getStringOrThrow(row, "string_value"),
+            )
+        }
+    }
+
+    @Test
+    fun `execute should succeed when valid query`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery("SELECT 1").use {
+                it.execute()
+            }
+        }
+    }
+
+    @Test
+    fun `fetchScalar should succeed when valid query with basic type`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery("SELECT 1").use {
+                val scalar = it.fetchScalar<Int>()
+                assertNotNull(scalar)
+                assertEquals(1, scalar)
+            }
+        }
+    }
+
+    @Test
+    fun `fetchScalar should succeed when valid query with custom type`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery("SELECT '{1,2,3}'::int[]").use {
+                val scalar = it.fetchScalar<List<Int>>()
+                assertNotNull(scalar)
+                Assertions.assertIterableEquals(listOf(1,2,3), scalar)
+            }
+        }
+    }
+
+    @Test
+    fun `fetchScalar should fail when query returns a different type`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery("SELECT 1").use {
+                assertThrows<IncorrectScalarType> { it.fetchScalar<List<Int>>() }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchFirst should succeed when valid query with rowparser`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery("SELECT $1 int_value, $2 string_value").use {
+                val row = it.bind(INT_VALUE)
+                    .bind(STRING_VALUE)
+                    .fetchFirst(GoodRowParserTest)
+                assertNotNull(row)
+                assertEquals(INT_VALUE, row.intValue)
+                assertEquals(STRING_VALUE, row.stringValue)
+            }
+        }
+    }
+
+    @Test
+    fun `fetchFirst should fail when bad row parser`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery("SELECT $1 int_value, $2 string_value").use {
+                it.bind(INT_VALUE)
+                it.bind(STRING_VALUE)
+                assertThrows<RowParseError> { it.fetchFirst(BadRowParserTest) }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchSingle should succeed when valid query with rowparser`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery("SELECT $1 int_value, $2 string_value").use {
+                val row = it.bind(INT_VALUE)
+                    .bind(STRING_VALUE)
+                    .fetchSingle(GoodRowParserTest)
+                assertNotNull(row)
+                assertEquals(INT_VALUE, row.intValue)
+                assertEquals(STRING_VALUE, row.stringValue)
+            }
+        }
+    }
+
+    @Test
+    fun `fetchSingle should fail when no rows are returned`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT $1 int_value, $2 string_value) t
+                    WHERE 1 = 2
+                """.trimIndent()
+            ).use {
+                it.bind(INT_VALUE)
+                it.bind(STRING_VALUE)
+                assertThrows<EmptyQueryResult> { it.fetchSingle(BadRowParserTest) }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchSingle should fail when multiple rows are returned`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT $1 int_value, $2 string_value) t
+                    CROSS JOIN generate_series(1,2) s
+                """.trimIndent()
+            ).use {
+                it.bind(INT_VALUE)
+                it.bind(STRING_VALUE)
+                assertThrows<TooManyRows> { it.fetchSingle(BadRowParserTest) }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchAll should succeed when valid query and row parser`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT $1 int_value, $2 string_value) t
+                    CROSS JOIN generate_series(1,2) s
+                """.trimIndent()
+            ).use {
+                val rows = it.bind(INT_VALUE)
+                    .bind(STRING_VALUE)
+                    .fetchAll(GoodRowParserTest)
+                assertEquals(2, rows.size)
+                for (row in rows) {
+                    assertEquals(INT_VALUE, row.intValue)
+                    assertEquals(STRING_VALUE, row.stringValue)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchAll should fail when unexpected exception is thrown`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT null int_value, $1 string_value) t
+                    CROSS JOIN generate_series(1,2) s
+                """.trimIndent()
+            ).use {
+                it.bind(STRING_VALUE)
+                val exception = assertThrows<RowParseError> { it.fetchAll(BadRowParserTest2) }
+                val suppressedExceptions = exception.suppressedExceptions
+                assertEquals(1, suppressedExceptions.size)
+                assertTrue(suppressedExceptions.first() is NullPointerException)
+            }
+        }
+    }
+
+    @Test
+    fun `fetch should succeed when valid query and row parser`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT $1 int_value, $2 string_value) t
+                    CROSS JOIN generate_series(1,2) s
+                """.trimIndent()
+            ).use {
+                val rows = it.bind(INT_VALUE)
+                    .bind(STRING_VALUE)
+                    .fetch(GoodRowParserTest)
+                var count = 0
+                for (row in rows) {
+                    count++
+                    assertEquals(INT_VALUE, row.intValue)
+                    assertEquals(STRING_VALUE, row.stringValue)
+                }
+                assertEquals(2, count)
+            }
+        }
+    }
+
+    companion object {
+        const val INT_VALUE = 1
+        const val STRING_VALUE = "test"
+    }
+}

--- a/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/query/TestPgBlockingQueryBatch.kt
+++ b/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/query/TestPgBlockingQueryBatch.kt
@@ -1,0 +1,36 @@
+package com.github.clasicrando.postgresql.query
+
+import com.github.clasicrando.common.connection.use
+import com.github.clasicrando.common.use
+import com.github.clasicrando.postgresql.PgConnectionHelper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestPgBlockingQueryBatch {
+    @Test
+    fun `executeQueries should return StatementResult`() {
+        PgConnectionHelper.defaultBlockingConnection().use { connection ->
+            connection.createQueryBatch().use { queryBatch ->
+                queryBatch.addQuery("SELECT $ID")
+                queryBatch.addQuery("SELECT $1::text")
+                    .bind(TEXT)
+                queryBatch.executeQueries().use { statementResult ->
+                    assertEquals(2, statementResult.size)
+
+                    val firstResult = statementResult[0]
+                    assertEquals(1, firstResult.rowsAffected)
+                    assertEquals(ID, firstResult.rows.first().getInt(0))
+
+                    val secondResult = statementResult[1]
+                    assertEquals(1, secondResult.rowsAffected)
+                    assertEquals(TEXT, secondResult.rows.first().getString(0))
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ID = 1
+        const val TEXT = "test"
+    }
+}

--- a/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/query/TestPgQuery.kt
+++ b/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/query/TestPgQuery.kt
@@ -1,0 +1,235 @@
+package com.github.clasicrando.postgresql.query
+
+import com.github.clasicrando.common.connection.use
+import com.github.clasicrando.common.exceptions.EmptyQueryResult
+import com.github.clasicrando.common.exceptions.IncorrectScalarType
+import com.github.clasicrando.common.exceptions.RowParseError
+import com.github.clasicrando.common.exceptions.TooManyRows
+import com.github.clasicrando.common.query.RowParser
+import com.github.clasicrando.common.query.getIntOrThrow
+import com.github.clasicrando.common.query.getStringOrThrow
+import com.github.clasicrando.common.result.DataRow
+import com.github.clasicrando.common.result.getInt
+import com.github.clasicrando.common.use
+import com.github.clasicrando.postgresql.PgConnectionHelper
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class TestPgQuery {
+    data class Row(val intValue: Int, val stringValue: String)
+
+    object GoodRowParserTest : RowParser<Row> {
+        override fun fromRow(row: DataRow): Row {
+            return Row(
+                intValue = getIntOrThrow(row, "int_value"),
+                stringValue = getStringOrThrow(row, "string_value"),
+            )
+        }
+    }
+
+    object BadRowParserTest : RowParser<Row> {
+        override fun fromRow(row: DataRow): Row {
+            return Row(
+                intValue = row.getInt(3)!!,
+                stringValue = getStringOrThrow(row, "string_value"),
+            )
+        }
+    }
+
+    object BadRowParserTest2 : RowParser<Row> {
+        override fun fromRow(row: DataRow): Row {
+            return Row(
+                intValue = row.getInt("int_value")!!,
+                stringValue = getStringOrThrow(row, "string_value"),
+            )
+        }
+    }
+
+    @Test
+    fun `execute should succeed when valid query`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery("SELECT 1").use {
+                it.execute()
+            }
+        }
+    }
+
+    @Test
+    fun `fetchScalar should succeed when valid query with basic type`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery("SELECT 1").use {
+                val scalar = it.fetchScalar<Int>()
+                assertNotNull(scalar)
+                assertEquals(1, scalar)
+            }
+        }
+    }
+
+    @Test
+    fun `fetchScalar should succeed when valid query with custom type`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery("SELECT '{1,2,3}'::int[]").use {
+                val scalar = it.fetchScalar<List<Int>>()
+                assertNotNull(scalar)
+                Assertions.assertIterableEquals(listOf(1,2,3), scalar)
+            }
+        }
+    }
+
+    @Test
+    fun `fetchScalar should fail when query returns a different type`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery("SELECT 1").use {
+                assertThrows<IncorrectScalarType> { it.fetchScalar<List<Int>>() }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchFirst should succeed when valid query with rowparser`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery("SELECT $1 int_value, $2 string_value").use {
+                val row = it.bind(INT_VALUE)
+                    .bind(STRING_VALUE)
+                    .fetchFirst(GoodRowParserTest)
+                assertNotNull(row)
+                assertEquals(INT_VALUE, row.intValue)
+                assertEquals(STRING_VALUE, row.stringValue)
+            }
+        }
+    }
+
+    @Test
+    fun `fetchFirst should fail when bad row parser`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery("SELECT $1 int_value, $2 string_value").use {
+                it.bind(INT_VALUE)
+                it.bind(STRING_VALUE)
+                assertThrows<RowParseError> { it.fetchFirst(BadRowParserTest) }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchSingle should succeed when valid query with rowparser`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery("SELECT $1 int_value, $2 string_value").use {
+                val row = it.bind(INT_VALUE)
+                    .bind(STRING_VALUE)
+                    .fetchSingle(GoodRowParserTest)
+                assertNotNull(row)
+                assertEquals(INT_VALUE, row.intValue)
+                assertEquals(STRING_VALUE, row.stringValue)
+            }
+        }
+    }
+
+    @Test
+    fun `fetchSingle should fail when no rows are returned`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT $1 int_value, $2 string_value) t
+                    WHERE 1 = 2
+                """.trimIndent()
+            ).use {
+                it.bind(INT_VALUE)
+                it.bind(STRING_VALUE)
+                assertThrows<EmptyQueryResult> { it.fetchSingle(BadRowParserTest) }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchSingle should fail when multiple rows are returned`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT $1 int_value, $2 string_value) t
+                    CROSS JOIN generate_series(1,2) s
+                """.trimIndent()
+            ).use {
+                it.bind(INT_VALUE)
+                it.bind(STRING_VALUE)
+                assertThrows<TooManyRows> { it.fetchSingle(BadRowParserTest) }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchAll should succeed when valid query and row parser`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT $1 int_value, $2 string_value) t
+                    CROSS JOIN generate_series(1,2) s
+                """.trimIndent()
+            ).use {
+                val rows = it.bind(INT_VALUE)
+                    .bind(STRING_VALUE)
+                    .fetchAll(GoodRowParserTest)
+                assertEquals(2, rows.size)
+                for (row in rows) {
+                    assertEquals(INT_VALUE, row.intValue)
+                    assertEquals(STRING_VALUE, row.stringValue)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `fetchAll should fail when unexpected exception is thrown`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT null int_value, $1 string_value) t
+                    CROSS JOIN generate_series(1,2) s
+                """.trimIndent()
+            ).use {
+                it.bind(STRING_VALUE)
+                val exception = assertThrows<RowParseError> { it.fetchAll(BadRowParserTest2) }
+                val suppressedExceptions = exception.suppressedExceptions
+                assertEquals(1, suppressedExceptions.size)
+                assertTrue(suppressedExceptions.first() is NullPointerException)
+            }
+        }
+    }
+
+    @Test
+    fun `fetch should succeed when valid query and row parser`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQuery(
+                """
+                    SELECT *
+                    FROM (SELECT $1 int_value, $2 string_value) t
+                    CROSS JOIN generate_series(1,2) s
+                """.trimIndent()
+            ).use {
+                val rows = it.bind(INT_VALUE)
+                    .bind(STRING_VALUE)
+                    .fetch(GoodRowParserTest)
+                var count = 0
+                rows.collect { row ->
+                    count++
+                    assertEquals(INT_VALUE, row.intValue)
+                    assertEquals(STRING_VALUE, row.stringValue)
+                }
+                assertEquals(2, count)
+            }
+        }
+    }
+
+    companion object {
+        const val INT_VALUE = 1
+        const val STRING_VALUE = "test"
+    }
+}

--- a/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/query/TestPgQueryBatch.kt
+++ b/postgresql/src/test/kotlin/com/github/clasicrando/postgresql/query/TestPgQueryBatch.kt
@@ -1,0 +1,37 @@
+package com.github.clasicrando.postgresql.query
+
+import com.github.clasicrando.common.connection.use
+import com.github.clasicrando.common.use
+import com.github.clasicrando.postgresql.PgConnectionHelper
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestPgQueryBatch {
+    @Test
+    fun `executeQueries should return StatementResult`(): Unit = runBlocking {
+        PgConnectionHelper.defaultConnection().use { connection ->
+            connection.createQueryBatch().use { queryBatch ->
+                queryBatch.addQuery("SELECT $ID")
+                queryBatch.addQuery("SELECT $1::text")
+                    .bind(TEXT)
+                queryBatch.executeQueries().use { statementResult ->
+                    assertEquals(2, statementResult.size)
+
+                    val firstResult = statementResult[0]
+                    assertEquals(1, firstResult.rowsAffected)
+                    assertEquals(ID, firstResult.rows.first().getInt(0))
+
+                    val secondResult = statementResult[1]
+                    assertEquals(1, secondResult.rowsAffected)
+                    assertEquals(TEXT, secondResult.rows.first().getString(0))
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ID = 1
+        const val TEXT = "test"
+    }
+}


### PR DESCRIPTION
Add easier to use query API for suspending and blocking connections. Allows users to query the database and parse results into desired data without having to interact with the underlining query results in the same way.